### PR TITLE
chore: address PR #32 code quality review feedback

### DIFF
--- a/src/Qwiq.Core/TypeParser.cs
+++ b/src/Qwiq.Core/TypeParser.cs
@@ -202,12 +202,10 @@ namespace Qwiq
                     result = converter.ConvertTo(value, converter.UnderlyingType);
                     return true;
                 }
-                // ReSharper disable CatchAllClause
-#pragma warning disable RECS0022 // A catch clause that catches System.Exception and has an empty body
                 catch
-#pragma warning restore RECS0022 // A catch clause that catches System.Exception and has an empty body
-                // ReSharper restore CatchAllClause
                 {
+                    // Intentionally empty: NullableConverter may fail for certain value types.
+                    // Fall through to try other conversion strategies.
                 }
 
             var valueType = value.GetType();
@@ -219,12 +217,10 @@ namespace Qwiq
                     result = typeConverter.ConvertTo(value, destinationType);
                     return true;
                 }
-                // ReSharper disable CatchAllClause
-#pragma warning disable RECS0022 // A catch clause that catches System.Exception and has an empty body
                 catch
-#pragma warning restore RECS0022 // A catch clause that catches System.Exception and has an empty body
-                // ReSharper restore CatchAllClause
                 {
+                    // Intentionally empty: TypeConverter.CanConvertTo may return true but still fail.
+                    // Fall through to try other conversion strategies.
                 }
 
             typeConverter = GetTypeConverter(destinationType);
@@ -234,12 +230,10 @@ namespace Qwiq
                     result = typeConverter.ConvertFrom(value);
                     return true;
                 }
-                // ReSharper disable CatchAllClause
-#pragma warning disable RECS0022 // A catch clause that catches System.Exception and has an empty body
                 catch
-#pragma warning restore RECS0022 // A catch clause that catches System.Exception and has an empty body
-                // ReSharper restore CatchAllClause
                 {
+                    // Intentionally empty: TypeConverter.CanConvertFrom may return true but still fail.
+                    // Fall through to try other conversion strategies.
                 }
 
             if (value != null)
@@ -252,12 +246,10 @@ namespace Qwiq
                             result = typeConverter.ConvertFromString(val);
                             return true;
                         }
-                        // ReSharper disable EmptyGeneralCatchClause
-#pragma warning disable RECS0022 // A catch clause that catches System.Exception and has an empty body
                         catch
-#pragma warning restore RECS0022 // A catch clause that catches System.Exception and has an empty body
-                        // ReSharper restore EmptyGeneralCatchClause
                         {
+                            // Intentionally empty: ConvertFromString may fail even when IsValid returns true.
+                            // Fall through to return null result.
                         }
             }
 

--- a/src/Qwiq.Core/WorkItemLinkTypeEnd.cs
+++ b/src/Qwiq.Core/WorkItemLinkTypeEnd.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Diagnostics.Contracts;
 
 
 namespace Qwiq
@@ -12,24 +11,19 @@ namespace Qwiq
         private readonly Lazy<IWorkItemLinkTypeEnd> _lazyOpposite;
 
         internal WorkItemLinkTypeEnd(string immutableName, IWorkItemLinkTypeEnd oppositeEnd)
+            : this(immutableName)
         {
-            Contract.Requires(!string.IsNullOrEmpty(immutableName));
-            Contract.Requires(oppositeEnd != null);
             _oppositeEnd = oppositeEnd ?? throw new ArgumentNullException(nameof(oppositeEnd));
         }
 
         internal WorkItemLinkTypeEnd(string immutableName, Lazy<IWorkItemLinkTypeEnd> oppositeEnd)
             : this(immutableName)
         {
-            Contract.Requires(!string.IsNullOrEmpty(immutableName));
-            Contract.Requires(oppositeEnd != null);
-
             _lazyOpposite = oppositeEnd ?? throw new ArgumentNullException(nameof(oppositeEnd));
         }
 
         internal WorkItemLinkTypeEnd(string immutableName)
         {
-            Contract.Requires(!string.IsNullOrEmpty(immutableName));
             if (string.IsNullOrWhiteSpace(immutableName))
                 throw new ArgumentException("Value cannot be null or whitespace.", nameof(immutableName));
 

--- a/src/Qwiq.Core/WorkItemTypeComparer.cs
+++ b/src/Qwiq.Core/WorkItemTypeComparer.cs
@@ -38,14 +38,11 @@ namespace Qwiq
             }
         }
 
-        // ReSharper disable ClassNeverInstantiated.Local
+        // ReSharper disable once ClassNeverInstantiated.Local
         private class Nested
-        // ReSharper restore ClassNeverInstantiated.Local
         {
-            // ReSharper disable MemberHidesStaticFromOuterClass
+            // ReSharper disable once MemberHidesStaticFromOuterClass
             internal static readonly WorkItemTypeComparer Instance = new WorkItemTypeComparer();
-
-            // ReSharper restore MemberHidesStaticFromOuterClass
 
             // Explicit static constructor to tell C# compiler
             // not to mark type as beforefieldinit


### PR DESCRIPTION
## Summary

This PR addresses code quality feedback from PR #32 (SDK-style modernization).

## Changes

### Code Quality Improvements

1. **WorkItemLinkTypeEnd.cs** - Remove duplicate validation
   - Removed redundant \Contract.Requires\ calls since runtime \ArgumentNullException\/\ArgumentException\ validation is already present
   - Removed unused \System.Diagnostics.Contracts\ using directive

2. **WorkItemTypeComparer.cs** - Fix ReSharper comment placement
   - Consolidated ReSharper disable/restore pairs to single-line \disable once\ comments

3. **TypeParser.cs** - Document intentional empty catch blocks
   - Added explanatory comments to each empty catch block explaining the fallback behavior
   - Removed unnecessary \#pragma warning disable\ and ReSharper suppression comments

## Testing

✅ All unit tests pass
✅ Build succeeds on all target frameworks

## Related

- Follows up on PR #32 review feedback
- See \.agents/PR31-COMMENT-SUMMARY.md\ for complete tracking